### PR TITLE
Update release.yml GITHUB_TOKEN permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,11 @@ on:
 env:
   GRADLE_OPTS: "-Dorg.gradle.daemon=false"
 
+permissions:
+  contents: write
+  metadata: read
+  packages: write
+
 jobs:
   prepare:
     name: Prepare


### PR DESCRIPTION
* in order for the workflow to be able to modify the repo content (increment the version) permissions are adjusted