### PR TITLE
Update release.yml GITHUB_TOKEN permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,6 @@ env:
 
 permissions:
   contents: write
-  metadata: read
   packages: write
 
 jobs:


### PR DESCRIPTION
* in order for the workflow to be able to modify the repo content (increment the version) permissions are adjusted