### PR TITLE
Extend Implementations to Align with SDMX-ML Model

### DIFF
--- a/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/ComponentValue.java
+++ b/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/ComponentValue.java
@@ -17,6 +17,16 @@ public interface ComponentValue extends Copyable {
     String getComponentId();
 
     /**
+     * Indicates whether the ComponentValue is included in the constraint definition or excluded from the constraint definition.
+     */
+    boolean isIncluded();
+
+    /**
+     * Indicates whether the Codes should keep or not the prefix, as defined in the extension of Codelist.
+     */
+    boolean isRemovePrefix();
+
+    /**
      * The values of the Time Dimension component.
      */
     List<TimeDimensionValue> getTimeDimensionValues();

--- a/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/ComponentValueImpl.java
+++ b/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/ComponentValueImpl.java
@@ -14,11 +14,15 @@ public class ComponentValueImpl implements ComponentValue {
 
     private String value;
     private String componentId;
+    private boolean included;
+    private boolean removePrefix;
     private List<TimeDimensionValue> timeDimensionValues = new ArrayList<>();
 
     public ComponentValueImpl(ComponentValue from) {
         this.value = from.getValue();
         this.componentId = from.getComponentId();
+        this.included = from.isIncluded();
+        this.removePrefix = from.isRemovePrefix();
         this.timeDimensionValues = StreamUtils.streamOfNullable(from.getTimeDimensionValues())
             .map(TimeDimensionValue::clone)
             .collect(toList());

--- a/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/CubeRegion.java
+++ b/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/CubeRegion.java
@@ -6,7 +6,7 @@ import java.util.List;
  * Defines a subset or "slice" of the total range of possible content of a data structure to
  * which the Constrainable Artefact is linked.
  */
-public interface CubeRegion extends Copyable {
+public interface CubeRegion extends AnnotableArtefact, Copyable {
 
     /**
      * Indicates whether the Cube Region is included in the constraint definition or excluded from the constraint definition.
@@ -17,6 +17,12 @@ public interface CubeRegion extends Copyable {
      * A set of permissible values for one component of the axis
      */
     List<MemberSelection> getMemberSelections();
+
+    /**
+     * Contains a reference to a component which disambiguates the data (i.e. a dimension)
+     * and provides a collection of values for the component.
+     */
+    List<CubeRegionKey> getCubeRegionKeys();
 
     @Override
     CubeRegion clone();

--- a/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/CubeRegionImpl.java
+++ b/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/CubeRegionImpl.java
@@ -4,18 +4,22 @@ import java.util.ArrayList;
 import java.util.List;
 
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
 @Data
 @NoArgsConstructor
-public class CubeRegionImpl implements CubeRegion {
+@EqualsAndHashCode(callSuper = true)
+public class CubeRegionImpl extends AnnotableArtefactImpl implements CubeRegion {
 
     private boolean included;
     private List<MemberSelection> memberSelections = new ArrayList<>();
+    private List<CubeRegionKey> cubeRegionKeys = new ArrayList<>();
 
     public CubeRegionImpl(CubeRegionImpl from) {
         this.included = from.isIncluded();
         this.memberSelections = from.getMemberSelections();
+        this.cubeRegionKeys = from.getCubeRegionKeys();
     }
 
     @Override

--- a/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/CubeRegionKey.java
+++ b/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/CubeRegionKey.java
@@ -1,0 +1,41 @@
+package com.epam.jsdmx.infomodel.sdmx30;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * CubeRegionKeyType is a type for providing a set of values
+ * for a dimension for the purpose of defining a data cube region
+ */
+public interface CubeRegionKey extends Copyable {
+
+    /**
+     * Indicates whether the Cube region key is included in the constraint definition or excluded from the constraint definition.
+     */
+    boolean isIncluded();
+
+    /**
+     * Indicates whether the Codes should keep or not the prefix, as defined in the extension of Codelist.
+     */
+    boolean isRemovePrefix();
+
+    /**
+     * Date from which the CubeRegionKey is valid.
+     */
+    Instant getValidFrom();
+
+    /**
+     * Date from which the CubeRegionKey is superseded.
+     */
+    Instant getValidTo();
+
+    /**
+     * A collection of values for a component
+     */
+    List<SelectionValue> getSelectionValues();
+
+    /**
+     * Provides the identifier for the component for which values are being provided
+     */
+    String getComponentId();
+}

--- a/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/CubeRegionKeyImpl.java
+++ b/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/CubeRegionKeyImpl.java
@@ -1,0 +1,38 @@
+package com.epam.jsdmx.infomodel.sdmx30;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@Getter
+@Setter
+@EqualsAndHashCode
+public class CubeRegionKeyImpl implements CubeRegionKey {
+
+    private boolean included;
+    private boolean removePrefix;
+    private String componentId;
+    private List<SelectionValue> selectionValues = new ArrayList<>();
+    private Instant validTo;
+    private Instant validFrom;
+
+    public CubeRegionKeyImpl(CubeRegionKeyImpl from) {
+        this.included = from.isIncluded();
+        this.removePrefix = from.isRemovePrefix();
+        this.componentId = from.getComponentId();
+        this.selectionValues = from.getSelectionValues();
+        this.validTo = from.getValidTo();
+        this.validFrom = from.getValidFrom();
+    }
+
+    @Override
+    public CubeRegionKeyImpl clone() {
+        return new CubeRegionKeyImpl(this);
+    }
+}

--- a/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/DataConsumerImpl.java
+++ b/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/DataConsumerImpl.java
@@ -1,0 +1,25 @@
+package com.epam.jsdmx.infomodel.sdmx30;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+@EqualsAndHashCode
+public class DataConsumerImpl extends OrganisationImpl<DataConsumer> implements DataConsumer {
+
+    public DataConsumerImpl(DataConsumerImpl from) {
+        super(from);
+    }
+
+    @Override
+    public StructureClass getStructureClass() {
+        return StructureClassImpl.DATA_CONSUMER;
+    }
+
+    @Override
+    public Object clone() {
+        return new DataConsumerImpl(this);
+    }
+}

--- a/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/DataKey.java
+++ b/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/DataKey.java
@@ -6,7 +6,7 @@ import java.util.List;
 /**
  * The values of a key in a data set.
  */
-public interface DataKey extends Copyable {
+public interface DataKey extends AnnotableArtefact, Copyable {
     /**
      * Indicates whether the Data Key Set is included in the constraint definition or excluded from the constraint definition.
      */
@@ -16,6 +16,13 @@ public interface DataKey extends Copyable {
      * Associates the Component Values that comprise the key
      */
     List<ComponentValue> getKeyValues();
+
+    /**
+     *
+     * contains a reference to a component (data attribute, metadata attribute, or measure)
+     * and provides a collection of values for the referenced component.
+     */
+    List<MemberSelection> getMemberSelections();
 
     /**
      * Date from which the Data Key is valid.

--- a/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/DataKeyImpl.java
+++ b/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/DataKeyImpl.java
@@ -7,14 +7,17 @@ import java.util.ArrayList;
 import java.util.List;
 
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
 @Data
 @NoArgsConstructor
-public class DataKeyImpl implements DataKey {
+@EqualsAndHashCode(callSuper = true)
+public class DataKeyImpl extends AnnotableArtefactImpl implements DataKey {
 
     private boolean included;
     private List<ComponentValue> keyValues = new ArrayList<>();
+    private List<MemberSelection> memberSelections = new ArrayList<>();
     private Instant validFrom;
     private Instant validTo;
 
@@ -24,6 +27,9 @@ public class DataKeyImpl implements DataKey {
         this.validTo = from.getValidTo();
         this.keyValues = StreamUtils.streamOfNullable(from.getKeyValues())
             .map(ComponentValue::clone)
+            .collect(toList());
+        this.memberSelections = StreamUtils.streamOfNullable(from.getMemberSelections())
+            .map(selection -> (MemberSelection) selection.clone())
             .collect(toList());
     }
 

--- a/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/MetadataTargetRegion.java
+++ b/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/MetadataTargetRegion.java
@@ -1,5 +1,6 @@
 package com.epam.jsdmx.infomodel.sdmx30;
 
+import java.time.Instant;
 import java.util.List;
 
 /**
@@ -17,4 +18,14 @@ public interface MetadataTargetRegion extends Copyable {
      * A set of permissible values for one component of the axis.
      */
     List<MemberSelection> getMemberSelections();
+
+    /**
+     * Date from which the MetadataTargetRegion is valid.
+     */
+    Instant getValidFrom();
+
+    /**
+     * Date from which the MetadataTargetRegion is superseded.
+     */
+    Instant getValidTo();
 }

--- a/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/MetadataTargetRegionImpl.java
+++ b/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/MetadataTargetRegionImpl.java
@@ -2,6 +2,7 @@ package com.epam.jsdmx.infomodel.sdmx30;
 
 import static java.util.stream.Collectors.toList;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -18,12 +19,16 @@ public class MetadataTargetRegionImpl implements MetadataTargetRegion {
 
     private boolean included;
     private List<MemberSelection> memberSelections = new ArrayList<>();
+    private Instant validTo;
+    private Instant validFrom;
 
     public MetadataTargetRegionImpl(MetadataTargetRegion from) {
         this.included = from.isIncluded();
         this.memberSelections = StreamUtils.streamOfNullable(from.getMemberSelections())
             .map(selection -> (MemberSelection) selection.clone())
             .collect(toList());
+        this.validTo = from.getValidTo();
+        this.validFrom = from.getValidFrom();
     }
 
     @Override

--- a/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/OrganisationUnitImpl.java
+++ b/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/OrganisationUnitImpl.java
@@ -1,0 +1,23 @@
+package com.epam.jsdmx.infomodel.sdmx30;
+
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+public class OrganisationUnitImpl extends OrganisationImpl<OrganisationUnit> implements OrganisationUnit {
+
+    public OrganisationUnitImpl(OrganisationUnit from) {
+        super(from);
+    }
+
+    @Override
+    public StructureClass getStructureClass() {
+        return StructureClassImpl.ORGANISATION_UNIT;
+    }
+
+    @Override
+    public Object clone() {
+        return new OrganisationUnitImpl(this);
+    }
+}

--- a/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/ProcessArtefact.java
+++ b/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/ProcessArtefact.java
@@ -3,7 +3,7 @@ package com.epam.jsdmx.infomodel.sdmx30;
 /**
  * Identification of an object that is an input to or an output from a Process Step.
  */
-public interface ProcessArtefact {
+public interface ProcessArtefact extends AnnotableArtefact {
     /**
      * Identification number of artefact.
      */

--- a/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/ProcessArtefactImpl.java
+++ b/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/ProcessArtefactImpl.java
@@ -8,8 +8,8 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
-@EqualsAndHashCode
-public class ProcessArtefactImpl implements ProcessArtefact {
+@EqualsAndHashCode(callSuper = true)
+public class ProcessArtefactImpl extends AnnotableArtefactImpl implements ProcessArtefact {
 
     private String localId;
     private ArtefactReference artefact;

--- a/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/ProcessStep.java
+++ b/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/ProcessStep.java
@@ -5,7 +5,7 @@ import java.util.List;
 /**
  * A specific operation, performed on data or metadata in order to validate or to derive new information according to a given set of rules.
  */
-public interface ProcessStep extends IdentifiableArtefact, Copyable {
+public interface ProcessStep extends NameableArtefact, Copyable {
     /**
      * Association to the Process Artefact that identifies the objects which are input to the Process Step.
      */

--- a/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/ProcessStepImpl.java
+++ b/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/ProcessStepImpl.java
@@ -12,7 +12,7 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 @EqualsAndHashCode(callSuper = true)
-public class ProcessStepImpl extends IdentifiableArtefactImpl implements ProcessStep {
+public class ProcessStepImpl extends NameableArtefactImpl implements ProcessStep {
 
     private List<ProcessArtefact> inputs = new ArrayList<>();
     private List<ProcessArtefact> outputs = new ArrayList<>();


### PR DESCRIPTION
1. **ComponentValue.java and ComponentValueImpl.java**: New methods were added to indicate whether the ComponentValue is included in the constraint definition or excluded from it, whether the Codes should keep or not the prefix, as defined in the extension of Codelist, and the values of the Time Dimension component.
2. **CubeRegion.java and CubeRegionImpl.java**: The CubeRegion interface now extends AnnotableArtefact. New methods were added to contain a reference to a **CubeRegionKey**
3. **CubeRegionKey.java and CubeRegionKeyImpl.java**: These are new classes added to provide a set of values for a dimension for the purpose of defining a data cube region.
4. **DataConsumerImpl.java**: This is a new class added for the implementation of DataConsumer.
5. **DataKey.java and DataKeyImpl.java**: The DataKey interface now extends AnnotableArtefact. New methods were added to contain a reference to a component (data attribute, metadata attribute, or measure) and provide a collection of values for the referenced component.
6. **MetadataTargetRegion.java and MetadataTargetRegionImpl.java**: New methods were added to indicate the date from which the MetadataTargetRegion is valid and the date from which it is superseded.
7. **OrganisationUnitImpl.java**: This is a new class added for the implementation of OrganisationUnit.
8. **ProcessArtefact.java and ProcessArtefactImpl.java**: The ProcessArtefact interface now extends AnnotableArtefact.
9. **ProcessStep.java and ProcessStepImpl.java**: The ProcessStep interface now extends NameableArtefact.
