### PR TITLE
Allow build VersionReference based on Version and WildcardScope

### DIFF
--- a/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/VersionReference.java
+++ b/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/VersionReference.java
@@ -25,7 +25,7 @@ public final class VersionReference extends AbstractVersionReference {
         Pair.of(PATCH_WILDCARD_PATTERN, (String s) -> new VersionReference(Version.createFromString(removeWildcard(s)), WildcardScope.PATCH))
     );
 
-    private VersionReference(Version version, WildcardScope scope) {
+    public VersionReference(Version version, WildcardScope scope) {
         super(version, scope);
     }
 


### PR DESCRIPTION
This change allow to create VersionReference based on Version and WildcardScope. 
For example:
Version version = Version.createFromString("3.0.0");
new VersionReference(version, WildcardScope.MAJOR) is equal to "3+.0.0" 