### PR TITLE
Add DSD References from Local Representations of Concepts

### DIFF
--- a/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/DataStructureDefinitionImpl.java
+++ b/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/DataStructureDefinitionImpl.java
@@ -1,5 +1,6 @@
 package com.epam.jsdmx.infomodel.sdmx30;
 
+import static java.util.Optional.ofNullable;
 import static java.util.function.Function.identity;
 import static java.util.function.Predicate.not;
 import static java.util.stream.Collectors.toList;
@@ -59,9 +60,16 @@ public class DataStructureDefinitionImpl
         return getComponentListsStream()
             .map(ComponentList::getComponents)
             .flatMap(List::stream)
-            .map(Component::getConceptIdentity)
-            .map(c -> toReference(c, StructureClassImpl.CONCEPT_SCHEME))
+            .flatMap(this::getComponentReferences)
             .collect(toSet());
+    }
+
+    private Stream<ArtefactReference> getComponentReferences(Component component) {
+        return Stream.<ArtefactReference>builder()
+            .add(toReference(component.getConceptIdentity(), StructureClassImpl.CONCEPT_SCHEME))
+            .add(ofNullable(component.getLocalRepresentation()).map(Representation::enumerated).orElse(null))
+            .build()
+            .filter(Objects::nonNull);
     }
 
     private Stream<ComponentList<? extends Component>> getComponentListsStream() {

--- a/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/IdentifiableArtefactImpl.java
+++ b/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/IdentifiableArtefactImpl.java
@@ -12,7 +12,7 @@ import lombok.SneakyThrows;
 @Getter
 @Setter
 @NoArgsConstructor
-@EqualsAndHashCode(callSuper = true, onlyExplicitlyIncluded = true)
+@EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
 public abstract class IdentifiableArtefactImpl
     extends AnnotableArtefactImpl
     implements IdentifiableArtefact {

--- a/sdmx30-infomodel/src/test/java/com/epam/jsdmx/infomodel/sdmx30/DataStructureDefinitionTest.java
+++ b/sdmx30-infomodel/src/test/java/com/epam/jsdmx/infomodel/sdmx30/DataStructureDefinitionTest.java
@@ -35,14 +35,15 @@ class DataStructureDefinitionTest {
 
         Set<CrossReference> crossReferences = subject.getReferencedArtefacts();
 
-        assertThat(crossReferences).hasSize(3);
+        assertThat(crossReferences).hasSize(4);
 
         assertThat(crossReferences)
             .extracting(CrossReference::getUrn)
             .containsExactlyInAnyOrder(
                 "urn:sdmx:org.sdmx.infomodel.conceptscheme.ConceptScheme=AGNC:MEASURE_CONCEPT_SCH_1(1.0)",
                 "urn:sdmx:org.sdmx.infomodel.conceptscheme.ConceptScheme=AGNC:MEASURE_CONCEPT_SCH_2(1.0)",
-                "urn:sdmx:org.sdmx.infomodel.conceptscheme.ConceptScheme=AGNC:MEASURE_CONCEPT_SCH_2(1.1)"
+                "urn:sdmx:org.sdmx.infomodel.conceptscheme.ConceptScheme=AGNC:MEASURE_CONCEPT_SCH_2(1.1)",
+                "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=AGNC:ID(1.0)"
             );
     }
 
@@ -51,6 +52,7 @@ class DataStructureDefinitionTest {
 
         var m1 = new MeasureImpl();
         m1.setConceptIdentity(new IdentifiableArtefactReferenceImpl("MEASURE_CONCEPT_SCH_1", "AGNC", "1.0", StructureClassImpl.CONCEPT, "cncpt"));
+        m1.setLocalRepresentation(new EnumeratedRepresentationImpl(new MaintainableArtefactReference("ID", "AGNC", "1.0", StructureClassImpl.CODELIST)));
 
         var m2 = new MeasureImpl();
         m2.setConceptIdentity(new IdentifiableArtefactReferenceImpl("MEASURE_CONCEPT_SCH_2", "AGNC", "1.0", StructureClassImpl.CONCEPT, "cncpt1"));
@@ -72,14 +74,15 @@ class DataStructureDefinitionTest {
 
         Set<CrossReference> crossReferences = subject.getReferencedArtefacts();
 
-        assertThat(crossReferences).hasSize(3);
+        assertThat(crossReferences).hasSize(4);
 
         assertThat(crossReferences)
             .extracting(CrossReference::getUrn)
             .containsExactlyInAnyOrder(
                 "urn:sdmx:org.sdmx.infomodel.conceptscheme.ConceptScheme=AGNC:DIMENSION_CONCEPT_SCH_1(1.0)",
                 "urn:sdmx:org.sdmx.infomodel.conceptscheme.ConceptScheme=AGNC:DIMENSION_CONCEPT_SCH_2(1.0)",
-                "urn:sdmx:org.sdmx.infomodel.conceptscheme.ConceptScheme=AGNC:DIMENSION_CONCEPT_SCH_2(1.1)"
+                "urn:sdmx:org.sdmx.infomodel.conceptscheme.ConceptScheme=AGNC:DIMENSION_CONCEPT_SCH_2(1.1)",
+                "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=AGNC:ID(1.0)"
             );
     }
 
@@ -88,6 +91,7 @@ class DataStructureDefinitionTest {
 
         var d1 = new DimensionImpl();
         d1.setConceptIdentity(new IdentifiableArtefactReferenceImpl("DIMENSION_CONCEPT_SCH_1", "AGNC", "1.0", StructureClassImpl.CONCEPT, "cncpt"));
+        d1.setLocalRepresentation(new EnumeratedRepresentationImpl(new MaintainableArtefactReference("ID", "AGNC", "1.0", StructureClassImpl.CODELIST)));
 
         var d2 = new DimensionImpl();
         d2.setConceptIdentity(new IdentifiableArtefactReferenceImpl("DIMENSION_CONCEPT_SCH_2", "AGNC", "1.0", StructureClassImpl.CONCEPT, "cncpt1"));
@@ -110,14 +114,15 @@ class DataStructureDefinitionTest {
 
         Set<CrossReference> crossReferences = subject.getReferencedArtefacts();
 
-        assertThat(crossReferences).hasSize(3);
+        assertThat(crossReferences).hasSize(4);
 
         assertThat(crossReferences)
             .extracting(CrossReference::getUrn)
             .containsExactlyInAnyOrder(
                 "urn:sdmx:org.sdmx.infomodel.conceptscheme.ConceptScheme=AGNC:ATTRIBUTE_CONCEPT_SCH_1(1.0)",
                 "urn:sdmx:org.sdmx.infomodel.conceptscheme.ConceptScheme=AGNC:ATTRIBUTE_CONCEPT_SCH_2(1.0)",
-                "urn:sdmx:org.sdmx.infomodel.conceptscheme.ConceptScheme=AGNC:ATTRIBUTE_CONCEPT_SCH_2(1.1)"
+                "urn:sdmx:org.sdmx.infomodel.conceptscheme.ConceptScheme=AGNC:ATTRIBUTE_CONCEPT_SCH_2(1.1)",
+                "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=AGNC:ID(1.0)"
             );
     }
 
@@ -126,6 +131,7 @@ class DataStructureDefinitionTest {
 
         var a1 = new DataAttributeImpl();
         a1.setConceptIdentity(new IdentifiableArtefactReferenceImpl("ATTRIBUTE_CONCEPT_SCH_1", "AGNC", "1.0", StructureClassImpl.CONCEPT, "cncpt"));
+        a1.setLocalRepresentation(new EnumeratedRepresentationImpl(new MaintainableArtefactReference("ID", "AGNC", "1.0", StructureClassImpl.CODELIST)));
 
         var a2 = new DataAttributeImpl();
         a2.setConceptIdentity(new IdentifiableArtefactReferenceImpl("ATTRIBUTE_CONCEPT_SCH_2", "AGNC", "1.0", StructureClassImpl.CONCEPT, "cncpt1"));
@@ -162,7 +168,9 @@ class DataStructureDefinitionTest {
                 "urn:sdmx:org.sdmx.infomodel.conceptscheme.ConceptScheme=AGNC:ATTRIBUTE_CONCEPT_SCH_1(1.0)",
                 "urn:sdmx:org.sdmx.infomodel.conceptscheme.ConceptScheme=AGNC:ATTRIBUTE_CONCEPT_SCH_2(1.0)",
                 "urn:sdmx:org.sdmx.infomodel.conceptscheme.ConceptScheme=AGNC:ATTRIBUTE_CONCEPT_SCH_2(1.1)",
-                "urn:sdmx:org.sdmx.infomodel.metadatastructure.MetadataStructure=META:meta(1.0)");
+                "urn:sdmx:org.sdmx.infomodel.metadatastructure.MetadataStructure=META:meta(1.0)",
+                "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=AGNC:ID(1.0)"
+            );
     }
 
 }

--- a/sdmx30-infomodel/src/test/java/com/epam/jsdmx/infomodel/sdmx30/DataStructureDefinitionTest.java
+++ b/sdmx30-infomodel/src/test/java/com/epam/jsdmx/infomodel/sdmx30/DataStructureDefinitionTest.java
@@ -169,8 +169,7 @@ class DataStructureDefinitionTest {
                 "urn:sdmx:org.sdmx.infomodel.conceptscheme.ConceptScheme=AGNC:ATTRIBUTE_CONCEPT_SCH_2(1.0)",
                 "urn:sdmx:org.sdmx.infomodel.conceptscheme.ConceptScheme=AGNC:ATTRIBUTE_CONCEPT_SCH_2(1.1)",
                 "urn:sdmx:org.sdmx.infomodel.metadatastructure.MetadataStructure=META:meta(1.0)",
-                "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=AGNC:ID(1.0)"
-            );
+                "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=AGNC:ID(1.0)");
     }
 
 }


### PR DESCRIPTION
* update DataStructureDefinitionImpl to return cross-references to codelists references from local representation, in case such exist
* reverts changes introduced in #24 