### PR TITLE
ItemScheme items (and dsd components) urn improvements (#36)

### DIFF
--- a/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/CodeImpl.java
+++ b/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/CodeImpl.java
@@ -23,7 +23,7 @@ public class CodeImpl
 
     @Override
     public StructureClass getStructureClass() {
-        return StructureClassImpl.CODELIST;
+        return StructureClassImpl.CODE;
     }
 
     @Override

--- a/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/IdentifiableArtefactImpl.java
+++ b/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/IdentifiableArtefactImpl.java
@@ -41,7 +41,7 @@ public abstract class IdentifiableArtefactImpl
         if (container == null) {
             throw new IllegalStateException("Get urn of non-maintainable object with null parent reference");
         }
-        return SdmxUrn.getItemUrnString(container.getUrn(), getId());
+        return SdmxUrn.getItemUrnString(container, this);
     }
 
     @Override

--- a/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/SdmxUrn.java
+++ b/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/SdmxUrn.java
@@ -98,8 +98,33 @@ public class SdmxUrn {
         return toShortItemUrnString(components.getAgency(), components.getId(), components.getVersion(), components.getItemId());
     }
 
+    /**
+     * @deprecated due to reporting incorrect structure class for items fo item schemes and (m)dsd components.
+     * Use {@link #getItemUrnString(ArtefactReference, IdentifiableArtefact)}
+     */
+    @Deprecated(forRemoval = true)
     public static String getItemUrnString(String containerUrn, String containedId) {
         return containerUrn + "." + containedId;
+    }
+
+    public static String getItemUrnString(ArtefactReference container, IdentifiableArtefact contained) {
+        if (container == null) {
+            throw new IllegalArgumentException("Container reference should not be null");
+        }
+        if (contained == null) {
+            throw new IllegalArgumentException("Contained artefact should not be null");
+        }
+        return toFullItemUrnString(
+            contained.getStructureClass(),
+            container.getOrganisationId(),
+            container.getId(),
+            getVersionString(container),
+            contained.getId()
+        );
+    }
+
+    private static String getVersionString(ArtefactReference ref) {
+        return ref != null && ref.getVersion() != null ? ref.getVersion().toString() : null;
     }
 
     private static String getStructureClass(String urn) {

--- a/sdmx30-infomodel/src/test/java/com/epam/jsdmx/infomodel/sdmx30/SdmxUrnTest.java
+++ b/sdmx30-infomodel/src/test/java/com/epam/jsdmx/infomodel/sdmx30/SdmxUrnTest.java
@@ -1,6 +1,7 @@
 package com.epam.jsdmx.infomodel.sdmx30;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -187,6 +188,47 @@ class SdmxUrnTest {
                 .version("1.42.69-draft")
                 .build())
         );
+    }
+
+    @Test
+    void testGetItemUrnString() {
+        var container = new MaintainableArtefactReference(
+            "parentId",
+            "agency",
+            "1.0.0",
+            StructureClassImpl.DATA_STRUCTURE
+        );
+
+        var contained = new DimensionImpl();
+        contained.setId("dimensionId");
+
+        var actual = SdmxUrn.getItemUrnString(container, contained);
+
+        assertThat(actual).isEqualTo("urn:sdmx:org.sdmx.infomodel.datastructure.Dimension=agency:parentId(1.0.0).dimensionId");
+    }
+
+    @Test
+    void testGetItemUrnString_whenContainerIsNull() {
+        var item = new DimensionImpl();
+        item.setId("dimensionId");
+
+        var t = assertThrows(IllegalArgumentException.class, () -> SdmxUrn.getItemUrnString(null, item));
+
+        assertThat(t).hasMessage("Container reference should not be null");
+    }
+
+    @Test
+    void testGetItemUrnString_whenContainedIsNull() {
+        var container = new MaintainableArtefactReference(
+            "parentId",
+            "agency",
+            "1.0.0",
+            StructureClassImpl.DATA_STRUCTURE
+        );
+
+        var t = assertThrows(IllegalArgumentException.class, () -> SdmxUrn.getItemUrnString(container, null));
+
+        assertThat(t).hasMessage("Contained artefact should not be null");
     }
 
 }


### PR DESCRIPTION
* fixes `Code` reporting its structure class as `Codelist` instead of `Code`
* fixes identifiable's `getUrn` method to return item type in prefix instead of the type of enclosing maintanable artefact. Add overload to sdmxUrn to support such change
* marks `getItemUrnString` old signature deprecated for removal