### PR TITLE
ItemScheme items (and dsd components) urn improvements (#38)

### DIFF
--- a/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/SdmxUrn.java
+++ b/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/SdmxUrn.java
@@ -119,7 +119,7 @@ public class SdmxUrn {
             container.getOrganisationId(),
             container.getId(),
             getVersionString(container),
-            contained.getId()
+            StringUtils.isEmpty(container.getItemId()) ? contained.getId() : container.getItemId() + "." + contained.getId()
         );
     }
 

--- a/sdmx30-infomodel/src/test/java/com/epam/jsdmx/infomodel/sdmx30/SdmxUrnTest.java
+++ b/sdmx30-infomodel/src/test/java/com/epam/jsdmx/infomodel/sdmx30/SdmxUrnTest.java
@@ -231,4 +231,22 @@ class SdmxUrnTest {
         assertThat(t).hasMessage("Contained artefact should not be null");
     }
 
+    @Test
+    void testGetItemUrnString_whenContainerIsItemItself() {
+        var container = new IdentifiableArtefactReferenceImpl(
+            "parentId",
+            "agency",
+            "1.0.0",
+            StructureClassImpl.CATEGORY,
+            "rootCategory"
+        );
+
+        var contained = new CategoryImpl();
+        contained.setId("childCategory");
+
+        var actual = SdmxUrn.getItemUrnString(container, contained);
+
+        assertThat(actual).isEqualTo("urn:sdmx:org.sdmx.infomodel.categoryscheme.Category=agency:parentId(1.0.0).rootCategory.childCategory");
+    }
+
 }


### PR DESCRIPTION
* fix composing urns for nested elements (elements, whose containers are elements themselves, e.g. category)