### PR TITLE
Optimise performance of the VersionReference#createFromString method

### DIFF
--- a/sdmx30-infomodel/build.gradle
+++ b/sdmx30-infomodel/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id "me.champeau.jmh" version "0.7.2"
+}
+
 dependencies {
     implementation("org.apache.commons:commons-collections4:${org_apache_commons_commons_collections4_version}")
     implementation("org.apache.commons:commons-lang3:${org_apache_commons_commons_lang3_version}")

--- a/sdmx30-infomodel/src/jmh/java/com/epam/jsdmx/infomodel/sdmx30/VersionReferenceBenchmark.java
+++ b/sdmx30-infomodel/src/jmh/java/com/epam/jsdmx/infomodel/sdmx30/VersionReferenceBenchmark.java
@@ -1,0 +1,34 @@
+package com.epam.jsdmx.infomodel.sdmx30;
+
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+
+public class VersionReferenceBenchmark {
+
+    @State(Scope.Thread)
+    public static class Versions {
+        public String fixedStable = "1.0.0";
+        public String fixedDraft = "1.0.0-draft";
+        public String wildcardPatch = "1.0.0+";
+        public String wildcardMinor = "1.0+.0";
+        public String wildcardMajor = "1+.0.0";
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    @OutputTimeUnit(TimeUnit.MILLISECONDS)
+    public void testCreateFromString(Versions versions, Blackhole bh) {
+        bh.consume(VersionReference.createFromString(versions.fixedStable));
+        bh.consume(VersionReference.createFromString(versions.fixedDraft));
+        bh.consume(VersionReference.createFromString(versions.wildcardPatch));
+        bh.consume(VersionReference.createFromString(versions.wildcardMinor));
+        bh.consume(VersionReference.createFromString(versions.wildcardMajor));
+    }
+}

--- a/sdmx30-infomodel/src/jmh/java/com/epam/jsdmx/infomodel/sdmx30/VersionReferenceBenchmark.java
+++ b/sdmx30-infomodel/src/jmh/java/com/epam/jsdmx/infomodel/sdmx30/VersionReferenceBenchmark.java
@@ -12,15 +12,6 @@ import org.openjdk.jmh.infra.Blackhole;
 
 public class VersionReferenceBenchmark {
 
-    @State(Scope.Thread)
-    public static class Versions {
-        public String fixedStable = "1.0.0";
-        public String fixedDraft = "1.0.0-draft";
-        public String wildcardPatch = "1.0.0+";
-        public String wildcardMinor = "1.0+.0";
-        public String wildcardMajor = "1+.0.0";
-    }
-
     @Benchmark
     @BenchmarkMode(Mode.Throughput)
     @OutputTimeUnit(TimeUnit.MILLISECONDS)
@@ -30,5 +21,14 @@ public class VersionReferenceBenchmark {
         bh.consume(VersionReference.createFromString(versions.wildcardPatch));
         bh.consume(VersionReference.createFromString(versions.wildcardMinor));
         bh.consume(VersionReference.createFromString(versions.wildcardMajor));
+    }
+
+    @State(Scope.Thread)
+    public static class Versions {
+        public String fixedStable = "1.0.0";
+        public String fixedDraft = "1.0.0-draft";
+        public String wildcardPatch = "1.0.0+";
+        public String wildcardMinor = "1.0+.0";
+        public String wildcardMajor = "1+.0.0";
     }
 }

--- a/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/VersionReference.java
+++ b/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/VersionReference.java
@@ -4,7 +4,6 @@ import static com.epam.jsdmx.infomodel.sdmx30.WildcardScope.MAJOR;
 import static com.epam.jsdmx.infomodel.sdmx30.WildcardScope.MINOR;
 import static com.epam.jsdmx.infomodel.sdmx30.WildcardScope.NONE;
 
-import java.nio.channels.IllegalChannelGroupException;
 import java.util.Comparator;
 import java.util.Objects;
 
@@ -26,7 +25,7 @@ public final class VersionReference extends AbstractVersionReference {
     public static VersionReference createFromString(String version) {
         try {
             return parse(version);
-        } catch (IllegalArgumentException e) {
+        } catch (IllegalArgumentException | IndexOutOfBoundsException e) {
             throw new IllegalArgumentException("Invalid version: " + version);
         }
     }
@@ -82,34 +81,34 @@ public final class VersionReference extends AbstractVersionReference {
                         patchFrom = i + 1;
                         break;
                     default:
-                        throw new IllegalChannelGroupException();
+                        throw new IllegalArgumentException();
                 }
             } else if (c == '-') {
                 extensionFrom = i + 1;
                 break;
             } else {
-                throw new IllegalArgumentException("Invalid version: " + version);
+                throw new IllegalArgumentException();
             }
         }
         short major = Short.parseShort(version.substring(0, majorUntil + 1));
 
         if (minorFrom == -1 || minorFrom >= inputLength || minorFrom > minorUntil || minorUntil < 0) {
-            throw new IllegalArgumentException("Invalid version: " + version);
+            throw new IllegalArgumentException();
         }
 
         short minor = Short.parseShort(version.substring(minorFrom, minorUntil + 1));
 
         if (patchFrom > 0 && patchFrom >= inputLength || patchFrom > patchUntil) {
-            throw new IllegalArgumentException("Invalid version: " + version);
+            throw new IllegalArgumentException();
         }
 
         short patch = patchFrom > 0 ? Short.parseShort(version.substring(patchFrom, patchUntil + 1)) : -1;
 
         if (extensionFrom > 0 && patchFrom == -1) {
-            throw new IllegalArgumentException("Invalid version: " + version);
+            throw new IllegalArgumentException();
         }
         if (extensionFrom > 0 && extensionFrom >= inputLength) {
-            throw new IllegalArgumentException("Invalid version: " + version);
+            throw new IllegalArgumentException();
         }
 
         String extension = extensionFrom == -1 ? null : version.substring(extensionFrom);

--- a/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/VersionReference.java
+++ b/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/VersionReference.java
@@ -68,7 +68,7 @@ public final class VersionReference extends AbstractVersionReference {
                     case PATCH:
                         scope = WildcardScope.PATCH;
                         break;
-                    case EXTENSION:
+                    default:
                         throw new IllegalArgumentException();
                 }
             } else if (c == '.') {
@@ -81,8 +81,7 @@ public final class VersionReference extends AbstractVersionReference {
                         p = Position.PATCH;
                         patchFrom = i + 1;
                         break;
-                    case PATCH:
-                    case EXTENSION:
+                    default:
                         throw new IllegalChannelGroupException();
                 }
             } else if (c == '-') {

--- a/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/VersionReference.java
+++ b/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/VersionReference.java
@@ -24,7 +24,7 @@ public final class VersionReference extends AbstractVersionReference {
         try {
             return parse(version);
         } catch (IllegalArgumentException | IndexOutOfBoundsException e) {
-            throw new IllegalArgumentException("Invalid version: " + version);
+            throw new IllegalArgumentException("Invalid version: " + version, e);
         }
     }
 

--- a/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/VersionReference.java
+++ b/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/VersionReference.java
@@ -1,12 +1,12 @@
 package com.epam.jsdmx.infomodel.sdmx30;
 
-import java.util.Comparator;
-import java.util.List;
-import java.util.Objects;
-import java.util.function.Function;
-import java.util.regex.Pattern;
+import static com.epam.jsdmx.infomodel.sdmx30.WildcardScope.MAJOR;
+import static com.epam.jsdmx.infomodel.sdmx30.WildcardScope.MINOR;
 
-import org.apache.commons.lang3.tuple.Pair;
+import java.util.Comparator;
+import java.util.Objects;
+
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Represents a wildcarded reference to a specific version of an artefact which is resolved according to the SDMX version management rules,
@@ -14,35 +14,66 @@ import org.apache.commons.lang3.tuple.Pair;
  */
 public final class VersionReference extends AbstractVersionReference {
 
-    private static final Pattern MAJOR_WILDCARD_PATTERN = Pattern.compile("(0|[1-9]\\d*)\\+\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(-\\w+)?");
-    private static final Pattern MINOR_WILDCARD_PATTERN = Pattern.compile("(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\+\\.(0|[1-9]\\d*)(-\\w+)?");
-    private static final Pattern PATCH_WILDCARD_PATTERN = Pattern.compile("(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\+(-\\w+)?");
-
-    private static final List<Pair<Pattern, Function<String, VersionReference>>> CREATORS_BY_PATTERN = List.of(
-        Pair.of(Version.PATTERN, (String s) -> new VersionReference(Version.createFromString(s), WildcardScope.NONE)),
-        Pair.of(MINOR_WILDCARD_PATTERN, (String s) -> new VersionReference(Version.createFromString(removeWildcard(s)), WildcardScope.MINOR)),
-        Pair.of(MAJOR_WILDCARD_PATTERN, (String s) -> new VersionReference(Version.createFromString(removeWildcard(s)), WildcardScope.MAJOR)),
-        Pair.of(PATCH_WILDCARD_PATTERN, (String s) -> new VersionReference(Version.createFromString(removeWildcard(s)), WildcardScope.PATCH))
-    );
-
     private VersionReference(Version version, WildcardScope scope) {
         super(version, scope);
     }
 
-    private static String removeWildcard(String s) {
-        return s.replaceAll("\\+", "");
-    }
-
     /**
      * Creates a {@link VersionReference} from a string representation.
+     *
      * @param version valid string representation of a referenced version
      */
     public static VersionReference createFromString(String version) {
-        return createFromString(CREATORS_BY_PATTERN, version);
+        final String[] split = StringUtils.split(version, '.');
+        if (split.length == 2) {
+            final short major = Short.parseShort(split[0]);
+            final short minor = Short.parseShort(split[1]);
+            return new VersionReference(Version.createFromComponents(major, minor), WildcardScope.NONE);
+        }
+        if (split.length != 3) {
+            throw new IllegalArgumentException("Invalid version format: " + version);
+        }
+        final WildcardScope scope = findWildcardScope(split);
+        final short major = Short.parseShort(scope == MAJOR ? StringUtils.substringBefore(split[0], '+') : split[0]);
+        final short minor = Short.parseShort(scope == MINOR ? StringUtils.substringBefore(split[1], '+') : split[1]);
+
+        final String[] patchSplit = StringUtils.split(split[2], '-');
+        short patch;
+        if (patchSplit.length > 1) {
+            if (scope != WildcardScope.NONE) {
+                // if the version is wildcarded, there is no extension expected
+                throw new IllegalArgumentException("Invalid version format: " + version);
+            }
+            patch = Short.parseShort(patchSplit[0]);
+        } else {
+            patch = Short.parseShort(scope == WildcardScope.PATCH ? StringUtils.substringBefore(split[2], '+') : split[2]);
+        }
+        return new VersionReference(
+            Version.createFromComponents(
+                major,
+                minor,
+                patch,
+                patchSplit.length > 1 ? StringUtils.substringAfter(split[2], "-") : ""
+            ),
+            scope
+        );
+    }
+
+    private static WildcardScope findWildcardScope(String[] components) {
+        if (StringUtils.endsWith(components[0], "+")) {
+            return MAJOR;
+        } else if (StringUtils.endsWith(components[1], "+")) {
+            return MINOR;
+        } else if (StringUtils.endsWith(components[2], "+")) {
+            return WildcardScope.PATCH;
+        } else {
+            return WildcardScope.NONE;
+        }
     }
 
     /**
      * Creates a {@link VersionReference} from a specific {@link Version}.
+     *
      * @param version version to be referenced
      */
     public static VersionReference createFromVersion(Version version) {
@@ -51,8 +82,9 @@ public final class VersionReference extends AbstractVersionReference {
 
     /**
      * Creates a {@link VersionReference} from a specific {@link Version} and {@link WildcardScope}.
+     *
      * @param version version to be referenced
-     * @param scope version component to wildcard
+     * @param scope   version component to wildcard
      */
     public static VersionReference createFromVersionAndWildcardScope(Version version, WildcardScope scope) {
         return new VersionReference(version, scope);

--- a/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/VersionReference.java
+++ b/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/VersionReference.java
@@ -1,7 +1,5 @@
 package com.epam.jsdmx.infomodel.sdmx30;
 
-import static com.epam.jsdmx.infomodel.sdmx30.WildcardScope.MAJOR;
-import static com.epam.jsdmx.infomodel.sdmx30.WildcardScope.MINOR;
 import static com.epam.jsdmx.infomodel.sdmx30.WildcardScope.NONE;
 
 import java.util.Comparator;
@@ -38,46 +36,46 @@ public final class VersionReference extends AbstractVersionReference {
         int patchFrom = -1;
         int patchUntil = -1;
         int extensionFrom = -1;
-        Position p = Position.MAJOR;
+        Position position = Position.IN_MAJOR;
         final int inputLength = version.length();
         for (int i = 0; i < inputLength; i++) {
             char c = version.charAt(i);
-            if (c > 47 & c < 58) {
-                switch (p) {
-                    case MAJOR:
+            if (c >= '0' & c <= '9') {
+                switch (position) {
+                    case IN_MAJOR:
                         majorUntil = i;
                         break;
-                    case MINOR:
+                    case IN_MINOR:
                         minorUntil = i;
                         break;
-                    case PATCH:
+                    case IN_PATCH:
                         patchUntil = i;
                         break;
                     default:
                         throw new IllegalArgumentException();
                 }
             } else if (c == '+') {
-                switch (p) {
-                    case MAJOR:
-                        scope = MAJOR;
+                switch (position) {
+                    case IN_MAJOR:
+                        scope = WildcardScope.MAJOR;
                         break;
-                    case MINOR:
-                        scope = MINOR;
+                    case IN_MINOR:
+                        scope = WildcardScope.MINOR;
                         break;
-                    case PATCH:
+                    case IN_PATCH:
                         scope = WildcardScope.PATCH;
                         break;
                     default:
                         throw new IllegalArgumentException();
                 }
             } else if (c == '.') {
-                switch (p) {
-                    case MAJOR:
-                        p = Position.MINOR;
+                switch (position) {
+                    case IN_MAJOR:
+                        position = Position.IN_MINOR;
                         minorFrom = i + 1;
                         break;
-                    case MINOR:
-                        p = Position.PATCH;
+                    case IN_MINOR:
+                        position = Position.IN_PATCH;
                         patchFrom = i + 1;
                         break;
                     default:
@@ -235,6 +233,6 @@ public final class VersionReference extends AbstractVersionReference {
     }
 
     private enum Position {
-        MAJOR, MINOR, PATCH, EXTENSION
+        IN_MAJOR, IN_MINOR, IN_PATCH, IN_EXTENSION
     }
 }

--- a/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/VersionReference.java
+++ b/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/VersionReference.java
@@ -93,13 +93,13 @@ public final class VersionReference extends AbstractVersionReference {
         }
         short major = Short.parseShort(version.substring(0, majorUntil + 1));
 
-        if (minorFrom == -1 || minorFrom >= inputLength) {
+        if (minorFrom == -1 || minorFrom >= inputLength || minorFrom > minorUntil || minorUntil < 0) {
             throw new IllegalArgumentException("Invalid version: " + version);
         }
 
         short minor = Short.parseShort(version.substring(minorFrom, minorUntil + 1));
 
-        if (patchFrom > 0 && patchFrom >= inputLength) {
+        if (patchFrom > 0 && patchFrom >= inputLength || patchFrom > patchUntil) {
             throw new IllegalArgumentException("Invalid version: " + version);
         }
 

--- a/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/VersionReference.java
+++ b/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/VersionReference.java
@@ -69,7 +69,7 @@ public final class VersionReference extends AbstractVersionReference {
                         scope = WildcardScope.PATCH;
                         break;
                     case EXTENSION:
-                        break;
+                        throw new IllegalArgumentException();
                 }
             } else if (c == '.') {
                 switch (p) {
@@ -86,7 +86,6 @@ public final class VersionReference extends AbstractVersionReference {
                         throw new IllegalChannelGroupException();
                 }
             } else if (c == '-') {
-                p = Position.EXTENSION;
                 extensionFrom = i + 1;
                 break;
             } else {

--- a/sdmx30-infomodel/src/test/java/com/epam/jsdmx/infomodel/sdmx30/VersionReferenceTest.java
+++ b/sdmx30-infomodel/src/test/java/com/epam/jsdmx/infomodel/sdmx30/VersionReferenceTest.java
@@ -28,10 +28,17 @@ class VersionReferenceTest {
             Arguments.of("1"),
             Arguments.of("1."),
             Arguments.of("1.0."),
+            Arguments.of("1.0-"),
+            Arguments.of("1.0.-"),
             Arguments.of("1.0-draft"),
             Arguments.of("1.0.0."),
             Arguments.of("1.0.0-"),
-            Arguments.of("1.aba.0")
+            Arguments.of("1.0.0.-"),
+            Arguments.of("1.aba.0"),
+            Arguments.of("abc"),
+            Arguments.of("-199.-44.-0"),
+            Arguments.of("199.-44.0"),
+            Arguments.of("199.44.-0")
         );
     }
 

--- a/sdmx30-infomodel/src/test/java/com/epam/jsdmx/infomodel/sdmx30/VersionReferenceTest.java
+++ b/sdmx30-infomodel/src/test/java/com/epam/jsdmx/infomodel/sdmx30/VersionReferenceTest.java
@@ -1,6 +1,7 @@
 package com.epam.jsdmx.infomodel.sdmx30;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Comparator;
 import java.util.stream.Stream;
@@ -11,6 +12,28 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 class VersionReferenceTest {
+
+    @ParameterizedTest
+    @MethodSource
+    void testInvalidFormats(String invalidInput) {
+        assertThrows(IllegalArgumentException.class, () -> VersionReference.createFromString(invalidInput));
+    }
+
+    private static Stream<Arguments> testInvalidFormats() {
+        return Stream.of(
+            Arguments.of(""),
+            Arguments.of("."),
+            Arguments.of("+"),
+            Arguments.of("-"),
+            Arguments.of("1"),
+            Arguments.of("1."),
+            Arguments.of("1.0."),
+            Arguments.of("1.0-draft"),
+            Arguments.of("1.0.0."),
+            Arguments.of("1.0.0-"),
+            Arguments.of("1.aba.0")
+        );
+    }
 
     @Test
     void createFixedVersionReference() {


### PR DESCRIPTION
* move away from using regular expressions to parse the string into it's components. Use linear path through characters of the string, marking corresponding indexes of start and end of each component. At the end of the walkthrough - 'substring' components from the input stream and parse into shorts. 
* extend `Version` public API to support creation of the version object using `short` values of components directly. 
* add `jmh` harness to validate performance improvement of the suggested changes. Might be useful as the basis for the next perf optimisations.

Results of the initial mesurements (**Before**):

| Benchmark | Mode |  Cnt | Score | Error | Units |
|---|---|---|---|---|---|
| VersionReferenceBenchmark.testCreateFromString | thrpt |  25 | 357.132 | ± 21.790 | ops/ms |

Results with suggested changes (**After**):
| Benchmark | Mode |  Cnt | Score | Error | Units |
|---|---|---|---|---|---|
| VersionReferenceBenchmark.testCreateFromString | thrpt |  25 | 1927.697 | ± 85.043 | ops/ms |