### PR TITLE
Optimise performance of the VersionReference#createFromString method

### DIFF
--- a/sdmx30-infomodel/build.gradle
+++ b/sdmx30-infomodel/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id "me.champeau.jmh" version "0.7.2"
+}
+
 dependencies {
     implementation("org.apache.commons:commons-collections4:${org_apache_commons_commons_collections4_version}")
     implementation("org.apache.commons:commons-lang3:${org_apache_commons_commons_lang3_version}")

--- a/sdmx30-infomodel/src/jmh/java/com/epam/jsdmx/infomodel/sdmx30/VersionReferenceBenchmark.java
+++ b/sdmx30-infomodel/src/jmh/java/com/epam/jsdmx/infomodel/sdmx30/VersionReferenceBenchmark.java
@@ -1,0 +1,34 @@
+package com.epam.jsdmx.infomodel.sdmx30;
+
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+
+public class VersionReferenceBenchmark {
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    @OutputTimeUnit(TimeUnit.MILLISECONDS)
+    public void testCreateFromString(Versions versions, Blackhole bh) {
+        bh.consume(VersionReference.createFromString(versions.fixedStable));
+        bh.consume(VersionReference.createFromString(versions.fixedDraft));
+        bh.consume(VersionReference.createFromString(versions.wildcardPatch));
+        bh.consume(VersionReference.createFromString(versions.wildcardMinor));
+        bh.consume(VersionReference.createFromString(versions.wildcardMajor));
+    }
+
+    @State(Scope.Thread)
+    public static class Versions {
+        public String fixedStable = "1.0.0";
+        public String fixedDraft = "1.0.0-draft";
+        public String wildcardPatch = "1.0.0+";
+        public String wildcardMinor = "1.0+.0";
+        public String wildcardMajor = "1+.0.0";
+    }
+}

--- a/sdmx30-infomodel/src/test/java/com/epam/jsdmx/infomodel/sdmx30/VersionReferenceTest.java
+++ b/sdmx30-infomodel/src/test/java/com/epam/jsdmx/infomodel/sdmx30/VersionReferenceTest.java
@@ -1,6 +1,7 @@
 package com.epam.jsdmx.infomodel.sdmx30;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Comparator;
 import java.util.stream.Stream;
@@ -11,6 +12,35 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 class VersionReferenceTest {
+
+    @ParameterizedTest
+    @MethodSource
+    void testInvalidFormats(String invalidInput) {
+        assertThrows(IllegalArgumentException.class, () -> VersionReference.createFromString(invalidInput));
+    }
+
+    private static Stream<Arguments> testInvalidFormats() {
+        return Stream.of(
+            Arguments.of(""),
+            Arguments.of("."),
+            Arguments.of("+"),
+            Arguments.of("-"),
+            Arguments.of("1"),
+            Arguments.of("1."),
+            Arguments.of("1.0."),
+            Arguments.of("1.0-"),
+            Arguments.of("1.0.-"),
+            Arguments.of("1.0-draft"),
+            Arguments.of("1.0.0."),
+            Arguments.of("1.0.0-"),
+            Arguments.of("1.0.0.-"),
+            Arguments.of("1.aba.0"),
+            Arguments.of("abc"),
+            Arguments.of("-199.-44.-0"),
+            Arguments.of("199.-44.0"),
+            Arguments.of("199.44.-0")
+        );
+    }
 
     @Test
     void createFixedVersionReference() {


### PR DESCRIPTION
PR: #42

* updates `Version` api to enable creation of the version with given `short` components
* gets rid of regex usage in `VersionReference#createFromString` factory method