### PR TITLE
Fix min/max occurs default values

### DIFF
--- a/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/DataAttributeImpl.java
+++ b/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/DataAttributeImpl.java
@@ -20,8 +20,8 @@ public class DataAttributeImpl
     extends AttributeComponentImpl
     implements DataAttribute {
 
-    private int minOccurs;
-    private int maxOccurs = Integer.MAX_VALUE;
+    private int minOccurs = 1;
+    private int maxOccurs = 1;
     private AttributeRelationship attributeRelationship;
     private MeasureRelationship measureRelationship;
     private List<ArtefactReference> conceptRoles = new ArrayList<>();

--- a/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/MeasureImpl.java
+++ b/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/MeasureImpl.java
@@ -19,8 +19,8 @@ public class MeasureImpl
     extends ComponentImpl
     implements Measure {
 
-    private int minOccurs;
-    private int maxOccurs;
+    private int minOccurs = 1;
+    private int maxOccurs = 1;
     private List<ArtefactReference> conceptRoles = new ArrayList<>();
 
     public MeasureImpl(Measure from) {

--- a/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/MetadataAttributeImpl.java
+++ b/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/MetadataAttributeImpl.java
@@ -21,7 +21,7 @@ public class MetadataAttributeImpl
 
     private boolean isPresentational;
     private int minOccurs = 1;
-    private int maxOccurs = Integer.MAX_VALUE;
+    private int maxOccurs = 1;
     private List<MetadataAttribute> hierarchy = new ArrayList<>();
 
     public MetadataAttributeImpl(MetadataAttribute from) {


### PR DESCRIPTION
* as per sdmx-ml default values for min and max occurs are equal to 1 for measures, data attributes and metadata attributes