### PR TITLE
Fix TextFormat with multiple facets (#45)

### DIFF
--- a/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/TextFormatImpl.java
+++ b/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/TextFormatImpl.java
@@ -27,11 +27,17 @@ public class TextFormatImpl implements TextFormat {
                 sentinelValues = f.getSentinelValues();
             }
 
+            final FacetValueType newValueType = f.getValueType();
+
+            if (newValueType == null) {
+                continue;
+            }
+
             if (valueType == null) {
-                valueType = f.getValueType();
+                valueType = newValueType;
             } else {
-                if (valueType != f.getValueType()) {
-                    throw new IllegalStateException("Inconsistent text format, multiple value types present: " + valueType + " and " + f.getValueType());
+                if (valueType != newValueType) {
+                    throw new IllegalStateException("Inconsistent text format, multiple value types present: " + valueType + " and " + newValueType);
                 }
             }
         }

--- a/sdmx30-infomodel/src/test/java/com/epam/jsdmx/infomodel/sdmx30/TextFormatImplTest.java
+++ b/sdmx30-infomodel/src/test/java/com/epam/jsdmx/infomodel/sdmx30/TextFormatImplTest.java
@@ -1,0 +1,25 @@
+package com.epam.jsdmx.infomodel.sdmx30;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+class TextFormatImplTest {
+
+    @Test
+    void shouldNotFailOnMultipleFacets() {
+        Facet f1 = new BaseFacetImpl(FacetValueType.STRING);
+        var f2 = new BaseFacetImpl();
+        f2.setType(FacetType.IS_MULTILINGUAL);
+        f2.setValue("true");
+
+        TextFormat value = assertDoesNotThrow(() -> new TextFormatImpl(Set.of(f1, f2)));
+
+        assertThat(value.getValueType()).contains(FacetValueType.STRING);
+        assertThat(value.getIsMultiLingual()).contains(true);
+    }
+
+}


### PR DESCRIPTION
* fixes TextFormatImpl failing on init when multiple facets are present due to 'inconsistent value type'