### PR TITLE
WildcardReferenceMatcher perf fix (#47)

### DIFF
--- a/sdmx30-infomodel/src/jmh/java/com/epam/jsdmx/infomodel/sdmx30/VersionReferenceHashCodeBenchmark.java
+++ b/sdmx30-infomodel/src/jmh/java/com/epam/jsdmx/infomodel/sdmx30/VersionReferenceHashCodeBenchmark.java
@@ -1,0 +1,31 @@
+package com.epam.jsdmx.infomodel.sdmx30;
+
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+
+public class VersionReferenceHashCodeBenchmark {
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    @OutputTimeUnit(TimeUnit.MICROSECONDS)
+    @Fork(value = 1, warmups = 1)
+    public void testHashcode(Subject subject, Blackhole bh) {
+        bh.consume(subject.hashCode());
+    }
+
+    @State(Scope.Thread)
+    public static class Subject {
+        VersionReference v = VersionReference.createFromVersionAndWildcardScope(
+            Version.createFromComponents((short) 1, (short) 0, (short) 0, null),
+            WildcardScope.MINOR
+        );
+    }
+}

--- a/sdmx30-infomodel/src/jmh/java/com/epam/jsdmx/infomodel/sdmx30/WildcardReferenceMatcherBenchmark.java
+++ b/sdmx30-infomodel/src/jmh/java/com/epam/jsdmx/infomodel/sdmx30/WildcardReferenceMatcherBenchmark.java
@@ -1,0 +1,34 @@
+package com.epam.jsdmx.infomodel.sdmx30;
+
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+
+public class WildcardReferenceMatcherBenchmark {
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    @OutputTimeUnit(TimeUnit.MILLISECONDS)
+    public void testMatches(Versions versions, Blackhole bh) {
+        bh.consume(versions.subject.matches(versions.input));
+    }
+
+    @State(Scope.Thread)
+    public static class Versions {
+        public WildcardReferenceMatcher subject = new WildcardReferenceMatcher(
+            VersionReference.createFromVersionAndWildcardScope(
+                Version.createFromComponents((short) 1, (short) 0, (short) 0, null),
+                WildcardScope.MINOR
+            )
+        );
+        public VersionReference input = VersionReference.createFromVersion(
+            Version.createFromComponents((short) 1, (short) 1, (short) 0, null)
+        );
+    }
+}

--- a/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/Version.java
+++ b/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/Version.java
@@ -62,6 +62,10 @@ public class Version {
         return new Version(version);
     }
 
+    public static Version createFromComponents(int major, int minor, int patch, String extension) {
+        return createFromComponents((short) major, (short) minor, (short) patch, extension);
+    }
+
     public static Version createFromComponents(short major, short minor, short patch, String extension) {
         return new Version(major, minor, patch, extension);
     }

--- a/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/VersionReference.java
+++ b/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/VersionReference.java
@@ -201,7 +201,9 @@ public final class VersionReference extends AbstractVersionReference {
 
     @Override
     public int hashCode() {
-        return this.toString().hashCode();
+        int result = base.hashCode();
+        result = 31 * result + scope.hashCode();
+        return result;
     }
 
     @Override
@@ -209,7 +211,8 @@ public final class VersionReference extends AbstractVersionReference {
         if (!(obj instanceof VersionReference)) {
             return false;
         }
-        return Objects.equals(this.toString(), obj.toString());
+        VersionReference other = (VersionReference) obj;
+        return Objects.equals(this.base, other.base) && Objects.equals(this.scope, other.scope);
     }
 
     private static final class Formatter {

--- a/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/WildcardReferenceMatcher.java
+++ b/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/WildcardReferenceMatcher.java
@@ -89,10 +89,14 @@ public class WildcardReferenceMatcher {
     }
 
     private VersionReference from() {
-        return VersionReference.createFromString(majorFrom + "." + minorFrom + "." + patchFrom + (isStable ? "" : "-draft"));
+        return VersionReference.createFromVersion(
+            Version.createFromComponents(majorFrom, minorFrom, patchFrom, isStable ? null : "draft")
+        );
     }
 
     private VersionReference to() {
-        return VersionReference.createFromString(majorTo + "." + minorTo + "." + patchTo);
+        return VersionReference.createFromVersion(
+            Version.createFromComponents(majorTo, minorTo, patchTo, null)
+        );
     }
 }

--- a/sdmx30-infomodel/src/test/java/com/epam/jsdmx/infomodel/sdmx30/WildcardReferenceMatcherTest.java
+++ b/sdmx30-infomodel/src/test/java/com/epam/jsdmx/infomodel/sdmx30/WildcardReferenceMatcherTest.java
@@ -1,0 +1,91 @@
+package com.epam.jsdmx.infomodel.sdmx30;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class WildcardReferenceMatcherTest {
+
+    @ParameterizedTest
+    @MethodSource
+    void testMajorWildcard(VersionReference candidate, boolean expected) {
+        final VersionReference ref = VersionReference.createFromVersionAndWildcardScope(
+            Version.createFromComponents(1, 0, 0, null),
+            WildcardScope.MAJOR
+        );
+
+        final var subject = new WildcardReferenceMatcher(ref);
+
+        assertThat(subject.matches(candidate)).isEqualTo(expected);
+
+    }
+
+    static Stream<Arguments> testMajorWildcard() {
+        return Stream.of(
+            Arguments.of(VersionReference.createFromVersion(Version.createFromComponents(1, 0, 0, null)), true),
+            Arguments.of(VersionReference.createFromVersion(Version.createFromComponents(1, 0, 1, null)), true),
+            Arguments.of(VersionReference.createFromVersion(Version.createFromComponents(1, 1, 1, null)), true),
+            Arguments.of(VersionReference.createFromVersion(Version.createFromComponents(1, 1, 0, null)), true),
+            Arguments.of(VersionReference.createFromVersion(Version.createFromComponents(2, 0, 0, null)), true),
+            Arguments.of(VersionReference.createFromVersion(Version.createFromComponents(2, 0, 1, null)), true),
+            Arguments.of(VersionReference.createFromVersion(Version.createFromComponents(2, 1, 1, null)), true)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void testMinorWildcard(VersionReference candidate, boolean expected) {
+        final VersionReference ref = VersionReference.createFromVersionAndWildcardScope(
+            Version.createFromComponents(1, 0, 0, null),
+            WildcardScope.MINOR
+        );
+
+        final var subject = new WildcardReferenceMatcher(ref);
+
+        assertThat(subject.matches(candidate)).isEqualTo(expected);
+
+    }
+
+    static Stream<Arguments> testMinorWildcard() {
+        return Stream.of(
+            Arguments.of(VersionReference.createFromVersion(Version.createFromComponents(1, 0, 0, null)), true),
+            Arguments.of(VersionReference.createFromVersion(Version.createFromComponents(1, 0, 1, null)), true),
+            Arguments.of(VersionReference.createFromVersion(Version.createFromComponents(1, 1, 1, null)), true),
+            Arguments.of(VersionReference.createFromVersion(Version.createFromComponents(1, 1, 0, null)), true),
+            Arguments.of(VersionReference.createFromVersion(Version.createFromComponents(2, 0, 0, null)), false),
+            Arguments.of(VersionReference.createFromVersion(Version.createFromComponents(2, 0, 1, null)), false),
+            Arguments.of(VersionReference.createFromVersion(Version.createFromComponents(2, 1, 1, null)), false)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void testPatchWildcard(VersionReference candidate, boolean expected) {
+        final VersionReference ref = VersionReference.createFromVersionAndWildcardScope(
+            Version.createFromComponents(1, 0, 0, null),
+            WildcardScope.PATCH
+        );
+
+        final var subject = new WildcardReferenceMatcher(ref);
+
+        assertThat(subject.matches(candidate)).isEqualTo(expected);
+
+    }
+
+    static Stream<Arguments> testPatchWildcard() {
+        return Stream.of(
+            Arguments.of(VersionReference.createFromVersion(Version.createFromComponents(1, 0, 0, null)), true),
+            Arguments.of(VersionReference.createFromVersion(Version.createFromComponents(1, 0, 1, null)), true),
+            Arguments.of(VersionReference.createFromVersion(Version.createFromComponents(1, 1, 1, null)), false),
+            Arguments.of(VersionReference.createFromVersion(Version.createFromComponents(1, 1, 0, null)), false),
+            Arguments.of(VersionReference.createFromVersion(Version.createFromComponents(2, 0, 0, null)), false),
+            Arguments.of(VersionReference.createFromVersion(Version.createFromComponents(2, 0, 1, null)), false),
+            Arguments.of(VersionReference.createFromVersion(Version.createFromComponents(2, 1, 1, null)), false)
+        );
+    }
+
+}


### PR DESCRIPTION
Changing the implementation of `from()` and `to()` methods to use `VersionReference#createFromComponents` which eliminates the need of string parsing.

* adds unit test for wildcardReferenceMatcher
* adds jmh to validate changes