### PR TITLE
Start migration of validFrom/validTo fields to String type (#51)

### DIFF
--- a/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/VersionableArtefact.java
+++ b/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/VersionableArtefact.java
@@ -14,12 +14,28 @@ public interface VersionableArtefact extends NameableArtefact {
     Version getVersion();
 
     /**
-     * Date from which the version is valid.
+     * Date from which the version is valid parsed as {@link Instant}.
+     *
+     * @deprecated migrate to sting version of this accessor to ensure support of all variations of ISO 8601 syntax
      */
+    @Deprecated(forRemoval = true)
     Instant getValidFrom();
+
+    /**
+     * Date from which version is superseded parsed as {@link Instant}.
+     *
+     * @deprecated migrate to sting version of this accessor to ensure support of all variations of ISO 8601 syntax
+     */
+    @Deprecated(forRemoval = true)
+    Instant getValidTo();
+
+    /**
+     * Date from which the version is valid as string.
+     */
+    String getValidFromString();
 
     /**
      * Date from which version is superseded.
      */
-    Instant getValidTo();
+    String getValidToString();
 }

--- a/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/VersionableArtefactImpl.java
+++ b/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/VersionableArtefactImpl.java
@@ -18,13 +18,33 @@ public abstract class VersionableArtefactImpl
 
     @EqualsAndHashCode.Include
     private Version version;
-    private Instant validFrom;
-    private Instant validTo;
+    private String validFrom;
+    private String validTo;
 
     protected VersionableArtefactImpl(VersionableArtefact artefact) {
         super(Objects.requireNonNull(artefact));
         this.version = artefact.getVersion();
-        this.validFrom = artefact.getValidFrom();
-        this.validTo = artefact.getValidTo();
+        this.validFrom = artefact.getValidFromString();
+        this.validTo = artefact.getValidToString();
+    }
+
+    @Override
+    public String getValidFromString() {
+        return validFrom;
+    }
+
+    @Override
+    public String getValidToString() {
+        return validTo;
+    }
+
+    @Override
+    public Instant getValidFrom() {
+        return Instant.parse(validFrom);
+    }
+
+    @Override
+    public Instant getValidTo() {
+        return Instant.parse(validTo);
     }
 }


### PR DESCRIPTION
* to ensure that users of the api can store any "ISO 8601"-compliant value, it is necessary to abandon Instant type
* leave old method for backward compatibility within 1.x.x version
* add new method which returns string value