### PR TITLE
Fix copy constructor of MetadataAttributeImpl

### DIFF
--- a/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/ComponentImpl.java
+++ b/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/ComponentImpl.java
@@ -20,7 +20,11 @@ public abstract class ComponentImpl
 
     public ComponentImpl(Component from) {
         super(Objects.requireNonNull(from));
-        this.conceptIdentity = new IdentifiableArtefactReferenceImpl(from.getConceptIdentity());
+
+        if (from.getConceptIdentity() != null) {
+            this.conceptIdentity = new IdentifiableArtefactReferenceImpl(from.getConceptIdentity());
+        }
+
         if (from.getLocalRepresentation() != null) {
             this.localRepresentation = (Representation) from.getLocalRepresentation().clone();
         }

--- a/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/MetadataAttributeImpl.java
+++ b/sdmx30-infomodel/src/main/java/com/epam/jsdmx/infomodel/sdmx30/MetadataAttributeImpl.java
@@ -29,7 +29,7 @@ public class MetadataAttributeImpl
         this.isPresentational = from.isPresentational();
         this.minOccurs = from.getMinOccurs();
         this.maxOccurs = from.getMaxOccurs();
-        this.hierarchy = StreamUtils.streamOfNullable(hierarchy)
+        this.hierarchy = StreamUtils.streamOfNullable(from.getHierarchy())
             .map(MetadataAttributeImpl::new)
             .collect(toList());
     }

--- a/sdmx30-infomodel/src/test/java/com/epam/jsdmx/infomodel/sdmx30/MetadataAttributeImplTest.java
+++ b/sdmx30-infomodel/src/test/java/com/epam/jsdmx/infomodel/sdmx30/MetadataAttributeImplTest.java
@@ -1,0 +1,42 @@
+package com.epam.jsdmx.infomodel.sdmx30;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class MetadataAttributeImplTest {
+
+    @Test
+    void testInit_shouldCorrectlyCopyNestedHierarchy() {
+        var rootAttribute1 = new MetadataAttributeImpl();
+        rootAttribute1.setId("root1");
+
+
+        var root1_child1 = new MetadataAttributeImpl();
+        root1_child1.setId("root1_child1");
+        var root1_child2 = new MetadataAttributeImpl();
+        root1_child2.setId("root1_child2");
+
+        var root1_child1_child1 = new MetadataAttributeImpl();
+        root1_child1_child1.setId("root1_child1_child1");
+
+        var root1_child2_child1 = new MetadataAttributeImpl();
+        root1_child2_child1.setId("root1_child2_child1");
+
+        rootAttribute1.setHierarchy(List.of(root1_child1, root1_child2));
+
+        root1_child1.setHierarchy(List.of(root1_child1_child1));
+
+        root1_child2.setHierarchy(List.of(root1_child2_child1));
+
+
+        var copy = new MetadataAttributeImpl(rootAttribute1);
+
+        assertThat(copy.getHierarchy()).hasSize(2);
+        assertThat(copy.getHierarchy().get(0).getHierarchy()).hasSize(1);
+        assertThat(copy.getHierarchy().get(1).getHierarchy()).hasSize(1);
+    }
+
+}


### PR DESCRIPTION
* fixes issue when chilld attributes (content of the hierarchy collection) is not copied when copy constructor is invoked